### PR TITLE
chore: Filtering arrays

### DIFF
--- a/src/components/NewsFilter.tsx
+++ b/src/components/NewsFilter.tsx
@@ -7,6 +7,7 @@ import {
   createEmptyFilters,
   filterItemsForNews,
   getInitialFiltersFromUrl,
+  toArray,
   type Filters,
   type FilterableItem,
 } from './filters';
@@ -68,7 +69,8 @@ function getItemHref(item: NewsItem, baseUrl: string): string | null {
 export default function NewsFilter({ items, baseUrl = '' }: NewsFilterProps) {
   const safeItems = Array.isArray(items) ? items : [];
   const allowedCouncilAcronyms = useMemo(
-    () => Array.from(new Set(safeItems.map((i) => i.councilAcronym).filter(Boolean))),
+    () =>
+      Array.from(new Set(safeItems.flatMap((i) => toArray(i.councilAcronym)))),
     [safeItems]
   );
   const [selectedFilters, setSelectedFilters] = useState<Filters>(() => 
@@ -233,9 +235,13 @@ export default function NewsFilter({ items, baseUrl = '' }: NewsFilterProps) {
                       {item.dateDisplay ?? formatDate(item.date)}
                     </time>
                   </div>
-                  {item.councilAcronym && (
+                  {toArray(item.councilAcronym).length > 0 && (
                     <ul className="usa-collection__meta content-tags news-tags" aria-label="Topics">
-                      <li className="usa-tag">{item.councilAcronym}</li>
+                      {toArray(item.councilAcronym).map((acronym) => (
+                        <li key={acronym} className="usa-tag">
+                          {acronym}
+                        </li>
+                      ))}
                     </ul>
                   )}
                   <p className="usa-collection__description margin-top-2 margin-bottom-0">{truncateDescription(item.description)}</p>

--- a/src/components/NewsFilter.tsx
+++ b/src/components/NewsFilter.tsx
@@ -235,13 +235,20 @@ export default function NewsFilter({ items, baseUrl = '' }: NewsFilterProps) {
                       {item.dateDisplay ?? formatDate(item.date)}
                     </time>
                   </div>
-                  {toArray(item.councilAcronym).length > 0 && (
+                  {[
+                    ...new Set([
+                      ...toArray(item.councilAcronym),
+                      ...(item.tags ?? []),
+                    ]),
+                  ].length > 0 && (
                     <ul className="usa-collection__meta content-tags news-tags" aria-label="Topics">
-                      {toArray(item.councilAcronym).map((acronym) => (
-                        <li key={acronym} className="usa-tag">
-                          {acronym}
-                        </li>
-                      ))}
+                      {[...new Set([...toArray(item.councilAcronym), ...(item.tags ?? [])])].map(
+                        (tag) => (
+                          <li key={tag} className="usa-tag">
+                            {tag}
+                          </li>
+                        )
+                      )}
                     </ul>
                   )}
                   <p className="usa-collection__description margin-top-2 margin-bottom-0">{truncateDescription(item.description)}</p>

--- a/src/components/ResourceFilter.tsx
+++ b/src/components/ResourceFilter.tsx
@@ -7,6 +7,7 @@ import {
   createEmptyFilters,
   filterItems,
   getInitialFiltersFromUrl,
+  toArray,
   type Filters,
   type FilterableItem,
 } from './filters';
@@ -15,9 +16,9 @@ interface Resource extends FilterableItem {
   id: string;
   title: string;
   description: string;
-  type: string;
-  focusArea: string;
-  councilAcronym: string;
+  type: string | string[];
+  focusArea: string | string[];
+  councilAcronym: string | string[];
   date: string;
   link: string;
 }
@@ -34,7 +35,10 @@ export default function ResourceFilter({ resources, baseUrl = '' }: ResourceFilt
 
   // Only allow ?council= to pre-select when it matches a council that exists in the data
   const allowedCouncilAcronyms = useMemo(
-    () => Array.from(new Set(safeResources.map((r) => r.councilAcronym).filter(Boolean))),
+    () =>
+      Array.from(
+        new Set(safeResources.flatMap((r) => toArray(r.councilAcronym)))
+      ),
     [safeResources]
   );
 
@@ -206,11 +210,21 @@ export default function ResourceFilter({ resources, baseUrl = '' }: ResourceFilt
                     <div className="usa-card__body">
                       <p>{resource.description}</p>
                       <div className="margin-top-2 content-tags">
-                        <span className="usa-tag">{resource.councilAcronym}</span>
-                        {resource.type && (
-                          <span className="usa-tag resource-tag--type">{resource.type}</span>
-                        )}
-                        {resource.focusArea && <span className="usa-tag">{resource.focusArea}</span>}
+                        {toArray(resource.councilAcronym).map((acronym) => (
+                          <span key={acronym} className="usa-tag">
+                            {acronym}
+                          </span>
+                        ))}
+                        {toArray(resource.type).map((t) => (
+                          <span key={t} className="usa-tag resource-tag--type">
+                            {t}
+                          </span>
+                        ))}
+                        {toArray(resource.focusArea).map((area) => (
+                          <span key={area} className="usa-tag">
+                            {area}
+                          </span>
+                        ))}
                       </div>
                     </div>
                     <div className="usa-card__footer">

--- a/src/components/filters.ts
+++ b/src/components/filters.ts
@@ -6,10 +6,16 @@ export type Filters = {
 };
 
 export type FilterableItem = {
-  councilAcronym?: string;
-  focusArea?: string;
-  type?: string;
+  councilAcronym?: string | string[];
+  focusArea?: string | string[];
+  type?: string | string[];
   date?: string;
+};
+
+/** Normalize a value that may be string or string[] to string[] */
+export const toArray = (value: string | string[] | undefined): string[] => {
+  if (value == null) return [];
+  return Array.isArray(value) ? value.filter(Boolean) : [value].filter(Boolean);
 };
 
 export const createEmptyFilters = (): Filters => ({
@@ -46,15 +52,18 @@ export const slugify = (value: string) =>
     .replace(/(^-+|-+$)/g, '') || 'item';
 
 export const matchesFilters = (item: FilterableItem, filters: Filters) => {
-  const councilValue = item.councilAcronym ?? '';
-  const focusAreaValue = item.focusArea ?? '';
-  const typeValue = item.type ?? '';
+  const councilValues = toArray(item.councilAcronym);
+  const focusAreaValues = toArray(item.focusArea);
+  const typeValues = toArray(item.type);
   const yearValue = getItemYear(item);
 
-  const councilMatch = filters.councils.length === 0 || filters.councils.includes(councilValue);
+  const councilMatch =
+    filters.councils.length === 0 || councilValues.some((c) => filters.councils.includes(c));
   const focusAreaMatch =
-    filters.focusAreas.length === 0 || filters.focusAreas.includes(focusAreaValue);
-  const typeMatch = filters.types.length === 0 || filters.types.includes(typeValue);
+    filters.focusAreas.length === 0 ||
+    focusAreaValues.some((f) => filters.focusAreas.includes(f));
+  const typeMatch =
+    filters.types.length === 0 || typeValues.some((t) => filters.types.includes(t));
   const yearMatch =
     filters.years.length === 0 ||
     (yearValue === '' && filters.years.includes(NO_YEAR_LABEL)) ||
@@ -75,7 +84,7 @@ export const buildFilterOptions = <T extends FilterableItem>(items: T[], selecte
             years: selected.years,
           })
         )
-        .map((item) => item.councilAcronym ?? ''),
+        .flatMap((item) => toArray(item.councilAcronym)),
       ...selected.councils,
     ])
   )
@@ -93,7 +102,7 @@ export const buildFilterOptions = <T extends FilterableItem>(items: T[], selecte
             years: selected.years,
           })
         )
-        .map((item) => item.focusArea ?? ''),
+        .flatMap((item) => toArray(item.focusArea)),
       ...selected.focusAreas,
     ])
   )
@@ -111,7 +120,7 @@ export const buildFilterOptions = <T extends FilterableItem>(items: T[], selecte
             years: selected.years,
           })
         )
-        .map((item) => item.type ?? ''),
+        .flatMap((item) => toArray(item.type)),
       ...selected.types,
     ])
   )
@@ -151,9 +160,10 @@ export const filterItems = <T extends FilterableItem>(items: T[], selected: Filt
 
 /** News/Events: only council and year filters. */
 export const matchesFiltersForNews = (item: FilterableItem, filters: Filters) => {
-  const councilValue = item.councilAcronym ?? '';
+  const councilValues = toArray(item.councilAcronym);
   const yearValue = getItemYear(item);
-  const councilMatch = filters.councils.length === 0 || filters.councils.includes(councilValue);
+  const councilMatch =
+    filters.councils.length === 0 || councilValues.some((c) => filters.councils.includes(c));
   const yearMatch =
     filters.years.length === 0 ||
     (yearValue === '' && filters.years.includes(NO_YEAR_LABEL)) ||
@@ -177,7 +187,7 @@ export const buildFilterOptionsForNews = <T extends FilterableItem>(
             years: selected.years,
           })
         )
-        .map((item) => item.councilAcronym ?? ''),
+        .flatMap((item) => toArray(item.councilAcronym)),
       ...selected.councils,
     ])
   )

--- a/src/data/news.json
+++ b/src/data/news.json
@@ -9,9 +9,7 @@
     "date": "2025-09-24",
     "dateDisplay": "September 24-25, 2025",
     "tags": [
-      "CDOC", 
-      "CDOC Summit",
-      "Data Without Barriers"
+      "Event"
     ],
     "type": "Event",
     "councilAcronym": "CDOC",
@@ -31,7 +29,8 @@
     "author": "Kirsten Dalboe, Federal Energy Regulatory Commission CDO, Chair of CDO Council and Steven Hernandez, Department of Education CISO, Co-Chair of CISO Council",    "type": "Guidance",
     "councilAcronym": "CDOC",
     "tags": [
-      "CDOC"
+      "News", 
+      "Guides"
     ],
     "body": [
       "Today, the CISO Council and CDO Council released the [Federal Zero Trust (ZT) Data Security Guide](https://resources.data.gov/assets/documents/Zero-Trust-DataSecurityGuide_RevisedMay2025_CIO.govVersion.pdf), a first-of-its-kind document and key deliverable of OMB M-22-09, Moving the U.S. Government Towards Zero Trust Cybersecurity Principles. M-22-09 charged the Federal CDO Council and Federal CISO Council to convene a cross-agency working group of data and security experts to develop a data security guide for Federal agencies.",

--- a/src/data/news.json
+++ b/src/data/news.json
@@ -9,7 +9,9 @@
     "date": "2025-09-24",
     "dateDisplay": "September 24-25, 2025",
     "tags": [
-      "CDOC"
+      "CDOC", 
+      "CDOC Summit",
+      "Data Without Barriers"
     ],
     "type": "Event",
     "councilAcronym": "CDOC",

--- a/src/pages/news-events/events/[slug].astro
+++ b/src/pages/news-events/events/[slug].astro
@@ -112,10 +112,10 @@ function renderBodyBlock(block: string): string {
             <div set:html={renderBodyBlock(block)} class="event-body-block" />
           ))}
       </div>
-      {toArray(item.councilAcronym).length > 0 && (
+      {[...new Set([...toArray(item.councilAcronym), ...(item.tags ?? [])])].length > 0 && (
         <ul class="usa-list usa-list--unstyled margin-top-4 content-tags" aria-label="Topics">
-          {toArray(item.councilAcronym).map((acronym) => (
-            <li class="usa-tag margin-bottom-1">{acronym}</li>
+          {[...new Set([...toArray(item.councilAcronym), ...(item.tags ?? [])])].map((tag) => (
+            <li class="usa-tag margin-bottom-1">{tag}</li>
           ))}
         </ul>
       )}

--- a/src/pages/news-events/events/[slug].astro
+++ b/src/pages/news-events/events/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../../layouts/BaseLayout.astro';
+import { toArray } from '../../../components/filters';
 import { marked } from 'marked';
 import newsItems from '../../../data/news.json';
 
@@ -17,15 +18,18 @@ const wavesUrl = `${baseUrl}assets/img/backgrounds/waves_2.svg`;
 
 const dateDisplay = item.dateDisplay || item.date;
 
-/** Related news & events: same council, sorted by date (newest first), limit 5. */
-const currentCouncil = item.councilAcronym;
+/** Related news & events: same council (shares at least one), sorted by date (newest first), limit 5. */
+const currentCouncils = toArray(item.councilAcronym);
+const sharesCouncil = (i: any) =>
+  currentCouncils.length > 0 &&
+  toArray(i.councilAcronym).some((c) => currentCouncils.includes(c));
 const relatedItems = (newsItems as any[])
   .filter(
     (i) =>
       i.slug &&
       i.slug !== item.slug &&
       (i.kind === 'news' || i.kind === 'event') &&
-      i.councilAcronym === currentCouncil
+      sharesCouncil(i)
   )
   .sort((a, b) => (b.date || '').localeCompare(a.date || ''))
   .slice(0, 5);
@@ -108,9 +112,11 @@ function renderBodyBlock(block: string): string {
             <div set:html={renderBodyBlock(block)} class="event-body-block" />
           ))}
       </div>
-      {item.councilAcronym && (
+      {toArray(item.councilAcronym).length > 0 && (
         <ul class="usa-list usa-list--unstyled margin-top-4 content-tags" aria-label="Topics">
-          <li class="usa-tag margin-bottom-1">{item.councilAcronym}</li>
+          {toArray(item.councilAcronym).map((acronym) => (
+            <li class="usa-tag margin-bottom-1">{acronym}</li>
+          ))}
         </ul>
       )}
         </div>

--- a/src/pages/news-events/news/[slug].astro
+++ b/src/pages/news-events/news/[slug].astro
@@ -104,10 +104,10 @@ const relatedItems = (newsItems as any[])
           <div set:html={renderBodyBlock(paragraph)} class="news-body-block" />
         ))}
       </div>
-      {toArray(item.councilAcronym).length > 0 && (
+      {[...new Set([...toArray(item.councilAcronym), ...(item.tags ?? [])])].length > 0 && (
         <ul class="usa-list usa-list--unstyled margin-top-4 content-tags" aria-label="Topics">
-          {toArray(item.councilAcronym).map((acronym) => (
-            <li class="usa-tag margin-bottom-1">{acronym}</li>
+          {[...new Set([...toArray(item.councilAcronym), ...(item.tags ?? [])])].map((tag) => (
+            <li class="usa-tag margin-bottom-1">{tag}</li>
           ))}
         </ul>
       )}

--- a/src/pages/news-events/news/[slug].astro
+++ b/src/pages/news-events/news/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../../layouts/BaseLayout.astro';
+import { toArray } from '../../../components/filters';
 import { marked } from 'marked';
 import newsItems from '../../../data/news.json';
 
@@ -42,15 +43,18 @@ function renderBodyBlock(block: string): string {
   return html;
 }
 
-/** Related news & events: same council, sorted by date (newest first), limit 5. */
-const currentCouncil = item.councilAcronym;
+/** Related news & events: same council (shares at least one), sorted by date (newest first), limit 5. */
+const currentCouncils = toArray(item.councilAcronym);
+const sharesCouncil = (i: any) =>
+  currentCouncils.length > 0 &&
+  toArray(i.councilAcronym).some((c) => currentCouncils.includes(c));
 const relatedItems = (newsItems as any[])
   .filter(
     (i) =>
       i.slug &&
       i.slug !== item.slug &&
       (i.kind === 'news' || i.kind === 'event') &&
-      i.councilAcronym === currentCouncil
+      sharesCouncil(i)
   )
   .sort((a, b) => (b.date || '').localeCompare(a.date || ''))
   .slice(0, 5);
@@ -100,9 +104,11 @@ const relatedItems = (newsItems as any[])
           <div set:html={renderBodyBlock(paragraph)} class="news-body-block" />
         ))}
       </div>
-      {item.councilAcronym && (
+      {toArray(item.councilAcronym).length > 0 && (
         <ul class="usa-list usa-list--unstyled margin-top-4 content-tags" aria-label="Topics">
-          <li class="usa-tag margin-bottom-1">{item.councilAcronym}</li>
+          {toArray(item.councilAcronym).map((acronym) => (
+            <li class="usa-tag margin-bottom-1">{acronym}</li>
+          ))}
         </ul>
       )}
         </div>


### PR DESCRIPTION
#76 

## Included in this PR
- Array support for filters and tags – focusArea, councilAcronym, and type in resources.json and councilAcronym in news.json can be strings or arrays. Filtering and display logic were updated to support both formats.
- News tags display – News and event items now show both councilAcronym and tags, with duplicates removed when a value appears in both.
- Related items logic – Related news and events are matched by shared councils when councilAcronym is an array, so items that share at least one council are shown as related.