### PR TITLE
78 update caioc council

### DIFF
--- a/src/components/filters.ts
+++ b/src/components/filters.ts
@@ -6,10 +6,16 @@ export type Filters = {
 };
 
 export type FilterableItem = {
-  councilAcronym?: string;
-  focusArea?: string;
-  type?: string;
+  councilAcronym?: string | string[];
+  focusArea?: string | string[];
+  type?: string | string[];
   date?: string;
+};
+
+/** Normalize a value that may be string or string[] to string[] */
+export const toArray = (value: string | string[] | undefined): string[] => {
+  if (value == null) return [];
+  return Array.isArray(value) ? value.filter(Boolean) : [value].filter(Boolean);
 };
 
 export const createEmptyFilters = (): Filters => ({
@@ -39,22 +45,27 @@ export const NO_YEAR_LABEL = 'No year';
 export const getItemYear = (item: FilterableItem) =>
   item.date ? item.date.split('-')[0].trim() : '';
 
-export const slugify = (value: string) =>
-  value
+export const slugify = (value: string | string[] | unknown): string => {
+  const str = Array.isArray(value) ? value[0] : value;
+  return (typeof str === 'string' ? str : String(str ?? ''))
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/(^-+|-+$)/g, '') || 'item';
+};
 
 export const matchesFilters = (item: FilterableItem, filters: Filters) => {
-  const councilValue = item.councilAcronym ?? '';
-  const focusAreaValue = item.focusArea ?? '';
-  const typeValue = item.type ?? '';
+  const councilValues = toArray(item.councilAcronym);
+  const focusAreaValues = toArray(item.focusArea);
+  const typeValues = toArray(item.type);
   const yearValue = getItemYear(item);
 
-  const councilMatch = filters.councils.length === 0 || filters.councils.includes(councilValue);
+  const councilMatch =
+    filters.councils.length === 0 || councilValues.some((c) => filters.councils.includes(c));
   const focusAreaMatch =
-    filters.focusAreas.length === 0 || filters.focusAreas.includes(focusAreaValue);
-  const typeMatch = filters.types.length === 0 || filters.types.includes(typeValue);
+    filters.focusAreas.length === 0 ||
+    focusAreaValues.some((f) => filters.focusAreas.includes(f));
+  const typeMatch =
+    filters.types.length === 0 || typeValues.some((t) => filters.types.includes(t));
   const yearMatch =
     filters.years.length === 0 ||
     (yearValue === '' && filters.years.includes(NO_YEAR_LABEL)) ||
@@ -75,7 +86,7 @@ export const buildFilterOptions = <T extends FilterableItem>(items: T[], selecte
             years: selected.years,
           })
         )
-        .map((item) => item.councilAcronym ?? ''),
+        .flatMap((item) => toArray(item.councilAcronym)),
       ...selected.councils,
     ])
   )
@@ -93,7 +104,7 @@ export const buildFilterOptions = <T extends FilterableItem>(items: T[], selecte
             years: selected.years,
           })
         )
-        .map((item) => item.focusArea ?? ''),
+        .flatMap((item) => toArray(item.focusArea)),
       ...selected.focusAreas,
     ])
   )
@@ -111,7 +122,7 @@ export const buildFilterOptions = <T extends FilterableItem>(items: T[], selecte
             years: selected.years,
           })
         )
-        .map((item) => item.type ?? ''),
+        .flatMap((item) => toArray(item.type)),
       ...selected.types,
     ])
   )
@@ -151,9 +162,10 @@ export const filterItems = <T extends FilterableItem>(items: T[], selected: Filt
 
 /** News/Events: only council and year filters. */
 export const matchesFiltersForNews = (item: FilterableItem, filters: Filters) => {
-  const councilValue = item.councilAcronym ?? '';
+  const councilValues = toArray(item.councilAcronym);
   const yearValue = getItemYear(item);
-  const councilMatch = filters.councils.length === 0 || filters.councils.includes(councilValue);
+  const councilMatch =
+    filters.councils.length === 0 || councilValues.some((c) => filters.councils.includes(c));
   const yearMatch =
     filters.years.length === 0 ||
     (yearValue === '' && filters.years.includes(NO_YEAR_LABEL)) ||
@@ -177,7 +189,7 @@ export const buildFilterOptionsForNews = <T extends FilterableItem>(
             years: selected.years,
           })
         )
-        .map((item) => item.councilAcronym ?? ''),
+        .flatMap((item) => toArray(item.councilAcronym)),
       ...selected.councils,
     ])
   )

--- a/src/content/councils/caioc/about.md
+++ b/src/content/councils/caioc/about.md
@@ -2,7 +2,7 @@
 title: About CAIOC
 councilName: Chief Artificial Intelligence Officers Council
 councilSlug: caioc
-logoPath: /assets/img/councils/CAIO.png
+logoPath: ""
 logoAlt: CAIOC Logo
 logoClass: council-logo
 shortDescription: The Chief Artificial Intelligence Officers Council serves as a Federal forum for Chief AI Officers to coordinate the development and utilization of artificial intelligence across the Federal government and the Executive Office of the President.

--- a/src/content/councils/caioc/about.md
+++ b/src/content/councils/caioc/about.md
@@ -1,0 +1,18 @@
+---
+title: About CAIOC
+councilName: Chief Artificial Intelligence Officers Council
+councilSlug: caioc
+logoPath: /assets/img/councils/CAIO.png
+logoAlt: CAIOC Logo
+logoClass: council-logo
+shortDescription: The Chief Artificial Intelligence Officers Council serves as a Federal forum for Chief AI Officers to coordinate the development and utilization of artificial intelligence across the Federal government and the Executive Office of the President.
+---
+
+## Overview
+
+The Chief Artificial Intelligence Officers (CAIO) Council serves as a Federal forum for Chief AI Officers to coordinate the development and utilization of artificial intelligence across the Federal government and the Executive Office of the President (EOP). The Federal Chief Information Officer chairs the Council. Its membership comprises agency Chief AI Officers, representatives from the White House Office of Science and Technology Policy, the Office of the Director of National Intelligence, and other agencies as designated by the Chair.
+
+## Purpose
+
+- Coordinate the development and use of AI across agencies' programs and operations, including enabling compliance with implementation of OMB Memoranda and all other applicable authorities.
+- Develop and promote shared templates, formats, technical resources, and exemplary uses of agency AI adoption and implementation.

--- a/src/content/councils/caioc/members-leaders.md
+++ b/src/content/councils/caioc/members-leaders.md
@@ -1,0 +1,18 @@
+---
+title: CAIOC Leadership & Members
+councilName: Chief Artificial Intelligence Officers Council
+councilSlug: caioc
+intro: The CAIOC is composed of Chief Artificial Intelligence Officers from Federal agencies who work together to improve government IT and AI practices. The CAIO Council is chaired by the Federal Chief Artificial Intelligence Officer. Its membership comprises agency Chief AI Officers, representatives from the White House Office of Science and Technology Policy, the Office of the Director of National Intelligence, and other agencies or Ex-Officio members as designated by the Chair.
+leaders:
+  - name: Gregory Barbaccia
+    description: Federal Chief Information Officer
+    agency: The Executive Office of the President
+members:
+  - name: Department of Agriculture
+  - name: Department of Commerce
+  - name: Department of Education
+  - name: Department of Energy
+  - name: Department of Health and Human Services
+  - name: Department of Homeland Security
+  - name: Department of Housing and Urban Development
+---

--- a/src/content/councils/icsp/members-leaders.md
+++ b/src/content/councils/icsp/members-leaders.md
@@ -77,7 +77,7 @@ members:
     agency: U.S. Agency for International Development
   - name: Alice Volz
     description: Microeconomic Surveys Unit
-    agency: Federal Reserve Board
+    agency: Board of Governors of the Federal Reserve System
   - name: William Wiatrowski
     description: Bureau of Labor Statistics
     agency: Department of Labor

--- a/src/data/resources.json
+++ b/src/data/resources.json
@@ -162,6 +162,66 @@
     },
     {
       "id": "FRPC-2",
+      "title": "Federal Property Management Reform Act of 2016 (P.L. 114-318)",
+      "description": "",
+      "type": "Legislation",
+      "focusArea": "Responsibilities",
+      "councilAcronym": "FRPC",
+      "date": "2016-01-01",
+      "link": "https://www.congress.gov/114/plaws/publ318/PLAW-114publ318.pdf"
+    },
+    {
+      "id": "FRPC-3",
+      "title": "Federal Assets Sale and Transfer Act of 2016 (P.L. 114-287)",
+      "description": "",
+      "type": "Legislation",
+      "focusArea": "Utilization",
+      "councilAcronym": "FRPC",
+      "date": "2016-01-01",
+      "link": "https://www.congress.gov/114/plaws/publ287/PLAW-114publ287.pdf"
+    },
+    {
+      "id": "FRPC-4",
+      "title": "Designation and Responsibilities of Agency Senior Real Property Officers (M-18-21)",
+      "description": "",
+      "type": "Memorandum",
+      "focusArea": "Responsibilities",
+      "councilAcronym": "FRPC",
+      "date": "2018-01-01",
+      "link": "https://www.whitehouse.gov/wp-content/uploads/2018/07/M-18-21.pdf"
+    },
+    {
+      "id": "FRPC-5",
+      "title": "Implementation of Agency-wide Real Property Capital Planning (M-20-03)",
+      "description": "",
+      "type": "Memorandum",
+      "focusArea": "Responsibilities",
+      "councilAcronym": "FRPC",
+      "date": "2019-01-01",
+      "link": "https://www.whitehouse.gov/wp-content/uploads/2019/11/M-20-03.pdf"
+    },
+    {
+      "id": "FRPC-6",
+      "title": "Secure Federal Leases from Espionage and Suspicious Entanglements Act (P.L. 116-276)",
+      "description": "",
+      "type": "Legislation",
+      "focusArea": "Responsibilities",
+      "councilAcronym": "FRPC",
+      "date": "2020-01-01",
+      "link": "https://www.congress.gov/116/plaws/publ276/PLAW-116publ276.pdf"
+    },
+    {
+      "id": "FRPC-7",
+      "title": "Utilizing Space and Improving Technology Act (P.L. 118-272)",
+      "description": "",
+      "type": "Legislation",
+      "focusArea": "Utilization",
+      "councilAcronym": "FRPC",
+      "date": "2024-01-01",
+      "link": "https://www.congress.gov/bill/118th-congress/senate-bill/4367/text"
+    },
+    {
+      "id": "FRPC-8",
       "title": "Implementation of the Utilizing Space Efficiently and Improving Technologies Act (M-25-25)",
       "description": "",
       "type": "Memorandum",
@@ -171,7 +231,17 @@
       "link": "https://www.whitehouse.gov/wp-content/uploads/2025/02/M-25-25-Implementation-of-the-Utilizing-Space-Efficiently-and-Improving-Technologies-Act.pdf"
     },
     {
-      "id": "FRPC-3",
+      "id": "FRPC-9",
+      "title": "Thomas R. Carper Water Resources Development Act of 2024 (P.L. 118-272)",
+      "description": "",
+      "type": "Legislation",
+      "focusArea": "Responsibilities",
+      "councilAcronym": "FRPC",
+      "date": "2025-01-01",
+      "link": "https://www.congress.gov/bill/118th-congress/senate-bill/4367/text"
+    },
+    {
+      "id": "FRPC-10",
       "title": "FRPP Summary Report Library",
       "description": "",
       "type": "Website",
@@ -181,7 +251,7 @@
       "link": "https://www.gsa.gov/policy-regulations/policy/real-property-policy-division-overview/data-collection-and-reports/frpp-summary-report-library"
     },
     {
-      "id": "FRPC-4",
+      "id": "FRPC-11",
       "title": "FRPP Data Dictionary",
       "description": "",
       "type": "Website",
@@ -191,7 +261,7 @@
       "link": "https://www.gsa.gov/policy-regulations/policy/real-property-policy-division-overview/asset-management/federal-real-property-council/frpc-guidance-library"
     },
     {
-      "id": "FRPC-5",
+      "id": "FRPC-12",
       "title": "Public Buildings Reform Board Website",
       "description": "",
       "type": "Website",
@@ -201,7 +271,7 @@
       "link": "https://www.pbrb.gov/"
     },
     {
-      "id": "FRPC-6",
+      "id": "FRPC-13",
       "title": "Business Standards Website",
       "description": "",
       "type": "Website",
@@ -211,7 +281,7 @@
       "link": "https://ussm.gsa.gov/fibf/"
     },
     {
-      "id": "FRPC-7",
+      "id": "FRPC-14",
       "title": "Map of Federal Real Property",
       "description": "",
       "type": "Website",

--- a/src/data/resources.json
+++ b/src/data/resources.json
@@ -212,16 +212,6 @@
     },
     {
       "id": "FRPC-7",
-      "title": "Utilizing Space and Improving Technology Act (P.L. 118-272)",
-      "description": "",
-      "type": "Legislation",
-      "focusArea": "Utilization",
-      "councilAcronym": "FRPC",
-      "date": "2024-01-01",
-      "link": "https://www.congress.gov/bill/118th-congress/senate-bill/4367/text"
-    },
-    {
-      "id": "FRPC-8",
       "title": "Implementation of the Utilizing Space Efficiently and Improving Technologies Act (M-25-25)",
       "description": "",
       "type": "Memorandum",
@@ -231,8 +221,8 @@
       "link": "https://www.whitehouse.gov/wp-content/uploads/2025/02/M-25-25-Implementation-of-the-Utilizing-Space-Efficiently-and-Improving-Technologies-Act.pdf"
     },
     {
-      "id": "FRPC-9",
-      "title": "Thomas R. Carper Water Resources Development Act of 2024 (P.L. 118-272)",
+      "id": "FRPC-8",
+      "title": "WRDA / USE IT Act",
       "description": "",
       "type": "Legislation",
       "focusArea": "Responsibilities",
@@ -241,7 +231,7 @@
       "link": "https://www.congress.gov/bill/118th-congress/senate-bill/4367/text"
     },
     {
-      "id": "FRPC-10",
+      "id": "FRPC-9",
       "title": "FRPP Summary Report Library",
       "description": "",
       "type": "Website",
@@ -251,7 +241,7 @@
       "link": "https://www.gsa.gov/policy-regulations/policy/real-property-policy-division-overview/data-collection-and-reports/frpp-summary-report-library"
     },
     {
-      "id": "FRPC-11",
+      "id": "FRPC-10",
       "title": "FRPP Data Dictionary",
       "description": "",
       "type": "Website",
@@ -261,7 +251,7 @@
       "link": "https://www.gsa.gov/policy-regulations/policy/real-property-policy-division-overview/asset-management/federal-real-property-council/frpc-guidance-library"
     },
     {
-      "id": "FRPC-12",
+      "id": "FRPC-11",
       "title": "Public Buildings Reform Board Website",
       "description": "",
       "type": "Website",
@@ -271,7 +261,7 @@
       "link": "https://www.pbrb.gov/"
     },
     {
-      "id": "FRPC-13",
+      "id": "FRPC-12",
       "title": "Business Standards Website",
       "description": "",
       "type": "Website",
@@ -281,7 +271,7 @@
       "link": "https://ussm.gsa.gov/fibf/"
     },
     {
-      "id": "FRPC-14",
+      "id": "FRPC-13",
       "title": "Map of Federal Real Property",
       "description": "",
       "type": "Website",

--- a/src/data/resources.json
+++ b/src/data/resources.json
@@ -629,6 +629,66 @@
       "councilAcronym": "FPC",
       "date": "",
       "link": "https://www.fpc.gov/assets/pdf/Privacy%20for%20CDOs.pdf"
+    },
+    {
+      "id": "CAIOC-1",
+      "title": "2024 AI Use Case Inventory",
+      "description": "",
+      "type": "Executive Order",
+      "focusArea": "Use Cases",
+      "councilAcronym": "CAIOC",
+      "date": "2024-01-01",
+      "link": "https://github.com/ombegov/2024-Federal-AI-Use-Case-Inventory"
+    },
+    {
+      "id": "CAIOC-2",
+      "title": "M-25-21, Accelerating Federal Use of AI through Innovation, Governance, and Public Trust",
+      "description": "",
+      "type": "Memorandum",
+      "focusArea": "Use of AI",
+      "councilAcronym": "CAIOC",
+      "date": "2025-01-01",
+      "link": "https://www.whitehouse.gov/wp-content/uploads/2025/02/M-25-21-Accelerating-Federal-Use-of-AI-through-Innovation-Governance-and-Public-Trust.pdf"
+    },
+    {
+      "id": "CAIOC-3",
+      "title": "M-25-22 Driving Efficient Acquisition of Artificial Intelligence in Government",
+      "description": "",
+      "type": "Memorandum",
+      "focusArea": "Acquisition of AI",
+      "councilAcronym": "CAIOC",
+      "date": "2025-01-01",
+      "link": "https://www.whitehouse.gov/wp-content/uploads/2025/02/M-25-22-Driving-Efficient-Acquisition-of-Artificial-Intelligence-in-Government.pdf"
+    },
+    {
+      "id": "CAIOC-4",
+      "title": "M-26-04 Increasing Public Trust in Artificial Intelligence Through Unbiased AI",
+      "description": "",
+      "type": "Memorandum",
+      "focusArea": "Unbiased AI",
+      "councilAcronym": "CAIOC",
+      "date": "2025-12-01",
+      "link": "https://www.whitehouse.gov/wp-content/uploads/2025/12/M-26-04-Increasing-Public-Trust-in-Artificial-Intelligence-Through-Unbiased-AI-Principles-1.pdf"
+    },
+    {
+      "id": "CAIOC-5",
+      "title": "Promoting the Use of Trustworthy Artificial Intelligence in the Federal Government",
+      "description": "",
+      "type": "Executive Order",
+      "focusArea": "Use of AI",
+      "councilAcronym": "CAIOC",
+      "date": "2020-01-01",
+      "link": "https://www.federalregister.gov/documents/2020/12/08/2020-27065/promoting-the-use-of-trustworthy-artificial-intelligence-in-the-federal-government"
+    },
+    {
+      "id": "CAIOC-6",
+      "title": "Removing Barriers to American Leadership in Artificial Intelligence",
+      "description": "",
+      "type": "Executive Order",
+      "focusArea": ["Use of AI", "Acquisition of AI"],
+      "councilAcronym": "CAIOC",
+      "date": "2025-01-01",
+      "link": "https://www.federalregister.gov/documents/2025/01/31/2025-02172/removing-barriers-to-american-leadership-in-artificial-intelligence"
     }
   ]
 }

--- a/src/layouts/CouncilLayout.astro
+++ b/src/layouts/CouncilLayout.astro
@@ -13,12 +13,14 @@ interface Props {
   logoAspect?: 'square';
   /** When false, the "Leadership & Members" side nav item is hidden. */
   hasMembersLeaders?: boolean;
+  /** When false, the "News & Events" side nav item is hidden. */
+  hasNewsEvents?: boolean;
 }
 
 import BaseLayout from './BaseLayout.astro';
 import ReturnToTop from '../components/ReturnToTop.astro';
 
-const { title, currentPage = "about", councilName, councilSlug, councilAcronym, logoPath, logoAlt, logoClass, logoAspect, hasMembersLeaders = true } = Astro.props;
+const { title, currentPage = "about", councilName, councilSlug, councilAcronym, logoPath, logoAlt, logoClass, logoAspect, hasMembersLeaders = true, hasNewsEvents = true } = Astro.props;
 const baseUrl = import.meta.env.BASE_URL;
 const wavesUrl = `${baseUrl}assets/img/backgrounds/waves_2.svg`;
 const withBase = (path?: string) => (path && path.startsWith('/') ? `${baseUrl}${path.slice(1)}` : path);
@@ -32,9 +34,9 @@ const allNavItems = [
   { href: `${baseUrl}news-events/${councilQuery}`, label: "News & Events", id: "news-events" },
   { href: resourcesHref, label: "Resources", id: "resources", external: resourcesExternal },
 ];
-const navItems = hasMembersLeaders
-  ? allNavItems
-  : allNavItems.filter((item) => item.id !== "members-leaders");
+let navItems = allNavItems;
+if (!hasMembersLeaders) navItems = navItems.filter((item) => item.id !== "members-leaders");
+if (!hasNewsEvents) navItems = navItems.filter((item) => item.id !== "news-events");
 ---
 
 <BaseLayout title={title || `${councilName} - Councils.gov`} currentPage={currentPage}>

--- a/src/layouts/CouncilLayout.astro
+++ b/src/layouts/CouncilLayout.astro
@@ -52,29 +52,29 @@ const navItems = hasMembersLeaders
         </li>
       </ol>
     </nav>
-    {logoPath && (
-      <section class="council-hero usa-section padding-y-3" style={`--council-waves-url: url(${wavesUrl})`}>
-        <div class="grid-container">
-          <div class="grid-row grid-gap sidebar-layout">
+    <section class="council-hero usa-section padding-y-3" style={`--council-waves-url: url(${wavesUrl})`}>
+      <div class="grid-container">
+        <div class={`grid-row grid-gap sidebar-layout${!logoPath ? ' council-hero__row--no-logo' : ''}`}>
+          {logoPath && (
             <div class="sidebar-layout__sidebar">
               <div class={`council-hero__logo-container${logoAspect === 'square' ? ' council-hero__logo-container--square' : ''}`}>
                 <img src={withBase(logoPath)} alt={logoAlt || `${councilName} Logo`} class={logoClass || "council-hero__logo"} />
               </div>
             </div>
-            <div class="sidebar-layout__main flex-justify-center">
-              <div class="council-hero__content">
-                <p class="council-hero__brow">{councilName}</p>
-                <h1 class="council-hero__title">
-                  {currentPage === "about" ? `About ${councilSlug.toUpperCase()}` : 
-                   currentPage === "members-leaders" ? `Leadership & Members` : 
-                   title || `${councilName}`}
-                </h1>
-              </div>
+          )}
+          <div class={`sidebar-layout__main flex-justify-center${!logoPath ? ' council-hero__main--no-logo' : ''}`}>
+            <div class="council-hero__content">
+              <p class="council-hero__brow">{councilName}</p>
+              <h1 class="council-hero__title">
+                {currentPage === "about" ? `About ${councilSlug.toUpperCase()}` : 
+                 currentPage === "members-leaders" ? `Leadership & Members` : 
+                 title || `${councilName}`}
+              </h1>
             </div>
           </div>
         </div>
-      </section>
-    )}
+      </div>
+    </section>
     <div class="usa-section">
       <div class="grid-container">
         <div class="grid-row grid-gap sidebar-layout">

--- a/src/pages/[council]/index.astro
+++ b/src/pages/[council]/index.astro
@@ -4,6 +4,7 @@ import matter from 'gray-matter';
 import { marked } from 'marked';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { toArray } from '../../components/filters';
 
 // Get all council about pages
 export async function getStaticPaths() {
@@ -29,6 +30,18 @@ export async function getStaticPaths() {
       const coChairs = mlFrontmatter.coChairs ?? [];
       hasMembersLeaders = [].concat(members, leaders, coChairs).length > 0;
     }
+
+    // Check if this council has any news/events for the side nav
+    const councilAcronym = (frontmatter.logoAlt as string)?.replace(/\s*Logo\s*$/i, '').trim() || (frontmatter.councilSlug as string)?.toUpperCase() || '';
+    const newsPath = join(process.cwd(), 'src/data/news.json');
+    let hasNewsEvents = false;
+    if (fs.existsSync(newsPath)) {
+      const newsData = JSON.parse(fs.readFileSync(newsPath, 'utf-8'));
+      const newsItems = Array.isArray(newsData) ? newsData : (newsData.items ?? newsData.data ?? []);
+      hasNewsEvents = newsItems.some((item: { councilAcronym?: string | string[] }) =>
+        toArray(item.councilAcronym).includes(councilAcronym)
+      );
+    }
     
     // Configure marked to add usa-list class to ul elements
     const renderer = new marked.Renderer();
@@ -51,12 +64,13 @@ export async function getStaticPaths() {
         frontmatter,
         htmlContent,
         hasMembersLeaders,
+        hasNewsEvents,
       },
     };
   }).filter(Boolean);
 }
 
-const { frontmatter, htmlContent, hasMembersLeaders } = Astro.props;
+const { frontmatter, htmlContent, hasMembersLeaders, hasNewsEvents } = Astro.props;
 const councilAcronym = (frontmatter.logoAlt as string)?.replace(/\s*Logo\s*$/i, '').trim() || (frontmatter.councilSlug as string)?.toUpperCase() || '';
 const baseUrl = import.meta.env.BASE_URL;
 // Prepend base URL to asset paths in markdown-rendered HTML (e.g. /assets/img/ICSP_chart.jpg) for production
@@ -77,6 +91,7 @@ const htmlWithBaseUrl = htmlContent.replace(
   logoClass={frontmatter.logoClass}
   logoAspect={frontmatter.logoAspect}
   hasMembersLeaders={hasMembersLeaders}
+  hasNewsEvents={hasNewsEvents}
 >
   <div set:html={htmlWithBaseUrl} />
 </CouncilLayout>

--- a/src/pages/[council]/members-leaders.astro
+++ b/src/pages/[council]/members-leaders.astro
@@ -3,6 +3,7 @@ import CouncilLayout from '../../layouts/CouncilLayout.astro';
 import matter from 'gray-matter';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { toArray } from '../../components/filters';
 
 // Get all council members-leaders pages
 export async function getStaticPaths() {
@@ -34,6 +35,18 @@ export async function getStaticPaths() {
     const coChairs = frontmatter.coChairs ?? [];
     const hasMembersLeaders = [].concat(members, leaders, coChairs).length > 0;
 
+    // Check if this council has any news/events for the side nav
+    const councilAcronym = (logoAlt as string)?.replace(/\s*Logo\s*$/i, '').trim() || (frontmatter.councilSlug as string)?.toUpperCase() || '';
+    const newsPath = join(process.cwd(), 'src/data/news.json');
+    let hasNewsEvents = false;
+    if (fs.existsSync(newsPath)) {
+      const newsData = JSON.parse(fs.readFileSync(newsPath, 'utf-8'));
+      const newsItems = Array.isArray(newsData) ? newsData : (newsData.items ?? newsData.data ?? []);
+      hasNewsEvents = newsItems.some((item: { councilAcronym?: string | string[] }) =>
+        toArray(item.councilAcronym).includes(councilAcronym)
+      );
+    }
+
     return {
       params: { council: councilSlug },
       props: {
@@ -43,12 +56,13 @@ export async function getStaticPaths() {
         logoClass,
         logoAspect,
         hasMembersLeaders,
+        hasNewsEvents,
       },
     };
   }).filter(Boolean);
 }
 
-const { frontmatter, logoPath, logoAlt, logoClass, logoAspect, hasMembersLeaders } = Astro.props;
+const { frontmatter, logoPath, logoAlt, logoClass, logoAspect, hasMembersLeaders, hasNewsEvents } = Astro.props;
 const councilAcronym = (logoAlt as string)?.replace(/\s*Logo\s*$/i, '').trim() || (frontmatter.councilSlug as string)?.toUpperCase() || '';
 const baseUrl = import.meta.env.BASE_URL;
 const withBase = (path?: string) => (path && path.startsWith('/') ? `${baseUrl}${path.slice(1)}` : path);
@@ -153,6 +167,7 @@ function getMemberImage(member: any): string | null {
   logoClass={logoClass}
   logoAspect={logoAspect}
   hasMembersLeaders={hasMembersLeaders}
+  hasNewsEvents={hasNewsEvents}
 >
   <h2>{frontmatter.title}</h2>
   

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -79,13 +79,17 @@ const withBase = (path: string | null | undefined) => {
           >
             <div class="usa-card__container">
               <div class="usa-card__media">
-                <div class="usa-card__img">
-                  <img
-                    src={withBase(council.logo)}
-                    alt={council.logoAlt || ''}
-                    class={council.logoClass || 'council-logo'}
-                  />
-                </div>
+                {council.logo ? (
+                  <div class="usa-card__img">
+                    <img
+                      src={withBase(council.logo)}
+                      alt={council.logoAlt || ''}
+                      class={council.logoClass || 'council-logo'}
+                    />
+                  </div>
+                ) : (
+                  <div class="usa-card__img usa-card__img--placeholder" aria-hidden="true" />
+                )}
               </div>
               <header class="usa-card__header text-center padding-top-1">
                 <h2 class="usa-card__heading">

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -552,6 +552,11 @@ footer.usa-footer .footer-grid-container,
   margin-right: auto;
 }
 
+/* Placeholder for cards without a logo - preserves spacing */
+.councils-grid .usa-card__img--placeholder {
+  background: transparent;
+}
+
 $councils-gap: 2rem;
 
 .councils-grid {
@@ -718,6 +723,7 @@ $councils-gap: 2rem;
   border-bottom: 6px solid var(--accent-color);
   background-size: 30%;
   background-blend-mode: color;
+
 }
 
 /* Consistent top spacing for main content below council hero (fixes uneven spacing e.g. EOC) */
@@ -1468,6 +1474,15 @@ footer.usa-footer .footer-grid-container,
 
     & > * {
       min-width: 0;
+    }
+  }
+
+  /* When no logo: no grid columns, full width, left aligned */
+  &.council-hero__row--no-logo {
+    @media (min-width: $breakpoint-tablet) {
+      grid-template-columns: 1fr;
+      width: 100%;
+      align-items: flex-start;
     }
   }
 }


### PR DESCRIPTION
#78 

## Included in this PR

- CAIOC council – Added Chief Artificial Intelligence Officers Council with about page, leadership & members, and 6 resources (memos, executive orders, use case inventory).
- No-logo council layout – CAIOC uses logoPath: "". Home page cards keep spacing with a placeholder; council hero keeps blue background and waves but uses full-width, left-aligned layout when there is no logo.
- CAIOC resources – Added 6 CAIOC resources (2024 AI Use Case Inventory, M-25-21, M-25-22, M-26-04, E.O. 13960, E.O. on Removing Barriers).
- Bug fix – slugify updated to handle non-string values and avoid toLowerCase errors when array values reach the filter panel.
- Updated council landing pages to remove the News and Events link in the sidenav if the council in question does not have news and events
- Updated FRPC resources content